### PR TITLE
63 add production docker compose

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:latest as app-builder
+FROM mhart/alpine-node:9.11.1 as app-builder
 
 ADD yarn.lock /yarn.lock
 ADD package.json /package.json
@@ -9,7 +9,7 @@ ENV PATH=$PATH:/node_modules/.bin
 WORKDIR /app
 COPY . /app
 
-RUN yarn
+RUN yarn --ignore-engines
 RUN yarn run build-css
 RUN yarn run build
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,13 @@
+version: '3.5'
+services:
+  client:
+    image: ludlun/mercury-client-dev
+    working_dir: /usr/share/nginx/html
+    deploy:
+      labels:
+        traefik.port: '80'
+        traefik.backend: 'mercury_client_dev'
+        traefik.docker.network: 'traefik'
+        traefik.frontend.rule: 'Host:mercury-dev.lndgrn.xyz'
+    env_file:
+      - .env

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -1,0 +1,13 @@
+version: '3.5'
+services:
+  client:
+    image: ludlun/mercury-client
+    working_dir: /usr/share/nginx/html
+    deploy:
+      labels:
+        traefik.port: '80'
+        traefik.backend: 'mercury_client'
+        traefik.docker.network: 'traefik'
+        traefik.frontend.rule: 'Host:mercury.lndgrn.xyz'
+    env_file:
+      - .env


### PR DESCRIPTION
Closes #63 

These changes and additions will make deploying possible and work at its best.

- Change node version from latest to 9.11.1 as latest, 10.0.0 would not build assets as of this time.
- Add docker-compose for dev and production deploys.